### PR TITLE
Redirect to add farm interface form when farm does not exist

### DIFF
--- a/ChickenChecker-1314-main/ChickenChecker-1314-main/core/urls.py
+++ b/ChickenChecker-1314-main/ChickenChecker-1314-main/core/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     path('integrator/<int:userid>', listComplexes, name='complexManagement'),
     path('integrator/complex/<int:complexid>', listCompFarms, name='ComplexView'),
     path('integrator/complex/delete/farm/<int:farmid>', deleteFarm),
-    path('integrator/complex/<int:complexid>/add/farm', addFarm),
+    path('integrator/complex/<int:complexid>/add/farm', addFarm, name="addfarm"),
     path('update_username', updateUsername, name='updateUsername'),
     path('update_password', updatePassword, name='updatePassword'),
     path('validate_password', validatePassword, name='validatePassword'),

--- a/ChickenChecker-1314-main/ChickenChecker-1314-main/core/views.py
+++ b/ChickenChecker-1314-main/ChickenChecker-1314-main/core/views.py
@@ -102,11 +102,13 @@ def addFarm(request, complexid):
 
 @api_view(['GET'])
 def listHouses(request, userid):
-	user = User.objects.get(id=userid)
-	farms = Farm.objects.filter(user=user)
-	houses = House.objects.filter(farm=farms[0])
-	serializer = HouseSerializer(houses, many=True)
-	return Response(serializer.data)
+    user = User.objects.get(id=userid)
+    farms = Farm.objects.filter(user=user)
+    if farms:
+        houses = House.objects.filter(farm=farms[0])
+        serializer = HouseSerializer(houses, many=True)
+        return Response(serializer.data)
+    return Response("No such farm", status=status.HTTP_404_NOT_FOUND)
 
 @api_view(['POST'])
 def updateUsername(request):

--- a/ChickenChecker-1314-main/ChickenChecker-1314-main/core/views.py
+++ b/ChickenChecker-1314-main/ChickenChecker-1314-main/core/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 from django.http import HttpResponse
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate
@@ -108,7 +108,8 @@ def listHouses(request, userid):
         houses = House.objects.filter(farm=farms[0])
         serializer = HouseSerializer(houses, many=True)
         return Response(serializer.data)
-    return Response("No such farm", status=status.HTTP_404_NOT_FOUND)
+    complexid = Complex.objects.get(user=user.id)
+    return redirect("addfarm", complexid.id)
 
 @api_view(['POST'])
 def updateUsername(request):


### PR DESCRIPTION
Have added checks and an HTTP response when the farm doesn't exist on the endpoint `listHouses` i.e. `/core/farmer/<int>`
Is that what issue #28 wants to prevent? Let me know if is this the kind of interface are you trying to achieve here.